### PR TITLE
Add script for uploading parquet from MinIO to ClickHouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# FastAPI ClickHouse Utilities
+
+## Upload Parquet from MinIO
+
+The `scripts/upload_parquet_minio.py` helper downloads a Parquet file from MinIO and uploads it into ClickHouse, timing the process. Configure MinIO and ClickHouse credentials via command line flags or environment variables.
+
+Example usage:
+
+```bash
+python scripts/upload_parquet_minio.py \
+  --bucket mybucket \
+  --object data.parquet \
+  --table parquet_data
+```
+
+## Generating Test Data
+
+`scripts/generate_parquet.py` creates a Parquet file with random integers for performance testing. By default it generates 10 million rows and 10 columns.
+
+```bash
+python scripts/generate_parquet.py --rows 10000000 --cols 10 --output data.parquet
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ clickhouse-driver==0.2.9
 python-jose==3.3.0 
 pydantic-settings==2.5.2
 python-multipart==0.0.9
+minio==7.2.5
+pyarrow==15.0.2
+numpy==1.26.4

--- a/scripts/generate_parquet.py
+++ b/scripts/generate_parquet.py
@@ -1,0 +1,30 @@
+import argparse
+import os
+import pyarrow as pa
+import pyarrow.parquet as pq
+import numpy as np
+
+
+def generate_table(num_rows: int, num_cols: int) -> pa.Table:
+    arrays = []
+    field_names = []
+    for i in range(num_cols):
+        field_names.append(f"col{i}")
+        arrays.append(pa.array(np.random.randint(0, 1_000_000, size=num_rows)))
+    return pa.Table.from_arrays(arrays, names=field_names)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate Parquet file with random data")
+    parser.add_argument("--rows", type=int, default=10_000_000, help="Number of rows")
+    parser.add_argument("--cols", type=int, default=10, help="Number of columns")
+    parser.add_argument("--output", default="data.parquet", help="Output parquet file")
+    args = parser.parse_args()
+
+    table = generate_table(args.rows, args.cols)
+    pq.write_table(table, args.output)
+    print(f"Generated {args.output} with {args.rows} rows and {args.cols} columns")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_parquet_minio.py
+++ b/scripts/upload_parquet_minio.py
@@ -1,0 +1,86 @@
+import argparse
+import io
+import os
+import time
+
+from minio import Minio
+import pyarrow as pa
+import pyarrow.parquet as pq
+from clickhouse_driver import Client
+
+
+def arrow_to_clickhouse(pa_type: pa.DataType) -> str:
+    if pa.types.is_integer(pa_type):
+        return "Int64"
+    if pa.types.is_floating(pa_type):
+        return "Float64"
+    if pa.types.is_boolean(pa_type):
+        return "UInt8"
+    if pa.types.is_timestamp(pa_type):
+        return "DateTime"
+    return "String"
+
+
+def read_parquet_from_minio(endpoint: str, access_key: str, secret_key: str, bucket: str, obj: str) -> pq.Table:
+    client = Minio(endpoint, access_key=access_key, secret_key=secret_key, secure=False)
+    response = client.get_object(bucket, obj)
+    try:
+        data = response.read()
+    finally:
+        response.close()
+        response.release_conn()
+    buffer = io.BytesIO(data)
+    return pq.read_table(buffer)
+
+
+def upload_table_to_clickhouse(table: pq.Table, ch_client: Client, dest_table: str):
+    columns = table.column_names
+    schema = ", ".join(
+        f"{name} {arrow_to_clickhouse(table.schema[i].type)}" for i, name in enumerate(columns)
+    )
+    create_sql = f"CREATE TABLE IF NOT EXISTS {dest_table} ({schema}) ENGINE = MergeTree() ORDER BY tuple()"
+    ch_client.execute(create_sql)
+    rows = list(zip(*[table.column(col).to_pylist() for col in columns]))
+    insert_sql = f"INSERT INTO {dest_table} ({', '.join(columns)}) VALUES"
+    ch_client.execute(insert_sql, rows)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upload parquet file from MinIO to ClickHouse")
+    parser.add_argument("--bucket", required=True, help="MinIO bucket name")
+    parser.add_argument("--object", required=True, help="Parquet object name")
+    parser.add_argument("--table", required=True, help="Destination ClickHouse table")
+    parser.add_argument("--minio-endpoint", default=os.environ.get("MINIO_ENDPOINT", "localhost:9000"))
+    parser.add_argument("--minio-access", default=os.environ.get("MINIO_ACCESS_KEY", "minioadmin"))
+    parser.add_argument("--minio-secret", default=os.environ.get("MINIO_SECRET_KEY", "minioadmin"))
+    parser.add_argument("--ch-host", default=os.environ.get("CLICKHOUSE_HOST", "localhost"))
+    parser.add_argument("--ch-port", type=int, default=int(os.environ.get("CLICKHOUSE_PORT", 9000)))
+    parser.add_argument("--ch-user", default=os.environ.get("CLICKHOUSE_USER", "default"))
+    parser.add_argument("--ch-password", default=os.environ.get("CLICKHOUSE_PASSWORD", ""))
+    parser.add_argument("--ch-db", default=os.environ.get("CLICKHOUSE_DATABASE", "default"))
+
+    args = parser.parse_args()
+
+    start = time.time()
+    table = read_parquet_from_minio(
+        endpoint=args.minio_endpoint,
+        access_key=args.minio_access,
+        secret_key=args.minio_secret,
+        bucket=args.bucket,
+        obj=args.object,
+    )
+
+    ch_client = Client(
+        host=args.ch_host,
+        port=args.ch_port,
+        user=args.ch_user,
+        password=args.ch_password,
+        database=args.ch_db,
+    )
+    upload_table_to_clickhouse(table, ch_client, args.table)
+    elapsed = time.time() - start
+    print(f"Uploaded {table.num_rows} rows in {elapsed:.2f} seconds")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `upload_parquet_minio.py` to download a parquet file from MinIO and load it into ClickHouse
- add `generate_parquet.py` helper for creating large parquet test data
- document usage in new README
- update requirements with `minio`, `pyarrow` and `numpy`

## Testing
- `python -m py_compile scripts/upload_parquet_minio.py scripts/generate_parquet.py`

------
https://chatgpt.com/codex/tasks/task_b_68883313f638832badc01ecb64271df4