### PR TITLE
Use ClickHouse HTTP port 8123

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 The `scripts/upload_parquet_minio.py` helper downloads a Parquet file from MinIO and uploads it into ClickHouse in batches, timing the process. Configure MinIO and ClickHouse credentials via command line flags or environment variables. Use `--drop-table` to recreate the table before loading.
 
+The script connects over ClickHouse's HTTP interface. By default this listens on port `8123`, so be sure to specify that port if your server uses the standard configuration.
+
 Example usage:
 
 ```bash
@@ -12,6 +14,7 @@ python scripts/upload_parquet_minio.py \
   --object data.parquet \
   --table parquet_data \
   --batch-size 100000 \
+  --ch-port 8123 \
   --drop-table
 ```
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,7 +5,7 @@ class Settings(BaseSettings):
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     CLICKHOUSE_HOST: str = "clickhouse"
-    CLICKHOUSE_PORT: int = 9000
+    CLICKHOUSE_PORT: int = 8123
     CLICKHOUSE_USER: str = "admin"
     CLICKHOUSE_PASSWORD: str = "password"
     CLICKHOUSE_DATABASE: str = "default"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         condition: service_healthy
     environment:
       - CLICKHOUSE_HOST=clickhouse
-      - CLICKHOUSE_PORT=9000
+      - CLICKHOUSE_PORT=8123
       - CLICKHOUSE_USER=admin
       - CLICKHOUSE_PASSWORD=password  
       - CLICKHOUSE_DATABASE=default

--- a/scripts/upload_parquet_minio.py
+++ b/scripts/upload_parquet_minio.py
@@ -72,7 +72,12 @@ def main():
     parser.add_argument("--minio-access", default=os.environ.get("MINIO_ACCESS_KEY", "minioadmin"))
     parser.add_argument("--minio-secret", default=os.environ.get("MINIO_SECRET_KEY", "minioadmin"))
     parser.add_argument("--ch-host", default=os.environ.get("CLICKHOUSE_HOST", "localhost"))
-    parser.add_argument("--ch-port", type=int, default=int(os.environ.get("CLICKHOUSE_PORT", 9000)))
+    parser.add_argument(
+        "--ch-port",
+        type=int,
+        default=int(os.environ.get("CLICKHOUSE_PORT", 8123)),
+        help="ClickHouse HTTP port (default 8123)",
+    )
     parser.add_argument("--ch-user", default=os.environ.get("CLICKHOUSE_USER", "default"))
     parser.add_argument("--ch-password", default=os.environ.get("CLICKHOUSE_PASSWORD", ""))
     parser.add_argument("--ch-db", default=os.environ.get("CLICKHOUSE_DATABASE", "default"))


### PR DESCRIPTION
## Summary
- update README with correct ClickHouse port
- default scripts to use HTTP port 8123
- align app config and docker compose with that port

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688986809b48832bb9a06b0f906c3cdf