### PR TITLE
Fix row insertion from Parquet batches

### DIFF
--- a/scripts/upload_parquet_minio.py
+++ b/scripts/upload_parquet_minio.py
@@ -56,7 +56,8 @@ def upload_table_to_clickhouse(
     create_sql = f"CREATE TABLE IF NOT EXISTS {dest_table} ({schema}) ENGINE = MergeTree() ORDER BY tuple()"
     ch_client.command(create_sql)
     for batch in table.to_batches(batch_size):
-        ch_client.insert(dest_table, batch.to_pylist(), column_names=columns)
+        rows = [list(row[c] for c in columns) for row in batch.to_pylist()]
+        ch_client.insert(dest_table, rows, column_names=columns)
 
 
 def main():


### PR DESCRIPTION
## Summary
- fix `upload_parquet_minio.py` to send row values rather than dict keys when inserting batches

## Testing
- `python -m py_compile scripts/upload_parquet_minio.py`
- `python -m py_compile scripts/generate_parquet.py`


------
https://chatgpt.com/codex/tasks/task_b_688b1ac7e8e4832b8a36a8b69a4ccafe