### PR TITLE
Optimize MinIO streaming and ClickHouse client

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -8,14 +8,11 @@ from app.core.config import settings
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
-    to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.utcnow() + expires_delta
-    else:
-        expire = datetime.utcnow() + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
-    return encoded_jwt
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode = {**data, "exp": expire}
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
 
 def get_current_user(token: str = Depends(oauth2_scheme)):
     credentials_exception = HTTPException(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-multipart==0.0.9
 minio==7.2.5
 pyarrow==15.0.2
 numpy==1.26.4
+backoff==2.2.1


### PR DESCRIPTION
## Summary
- stream parquet files from MinIO directly into memory
- simplify Arrow type mapping
- retry ClickHouse connection using `backoff`
- shorten `create_access_token`
- add `backoff` dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b2888a44c832b9b51bc681c1a16ce