### PR TITLE
Add register endpoint

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, HTTPException, status, Depends
 from fastapi.security import OAuth2PasswordRequestForm
+from pydantic import BaseModel
+
 from app.core.security import create_access_token
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -7,9 +9,27 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 fake_users_db = {
     "admin": {
         "username": "admin",
-        "password": "password"
+        "password": "password",
+    }
 }
-}
+
+
+class RegisterForm(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/register")
+async def register(user: RegisterForm):
+    if user.username in fake_users_db:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    fake_users_db[user.username] = {
+        "username": user.username,
+        "password": user.password,
+    }
+    access_token = create_access_token(data={"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}
+
 
 @router.post("/login")
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):


### PR DESCRIPTION
## Summary
- add user registration route that persists in-memory and returns a token

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6892b8441158832bb69829b2ec406d42