### PR TITLE
feat: add dynamic SQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,25 @@ LEFT JOIN dim_users u ON o.user_id = u.id
 LEFT JOIN dim_products p ON o.product_id = p.id;
 ```
 
+### Thực thi truy vấn SQL động
+
+API cung cấp endpoint `/sql` để chạy bất kỳ câu lệnh nào tới ClickHouse với
+tham số động.  Điều này giúp bạn thao tác với các bảng tự định nghĩa thay vì
+chỉ các bảng mẫu trong ví dụ.
+
+Ví dụ thực thi truy vấn `SELECT`:
+
+```bash
+Invoke-RestMethod -Uri http://localhost:8000/sql/ `
+  -Method POST -ContentType 'application/json' `
+  -Body '{"sql":"SELECT count() FROM dim_users WHERE id={id:UInt64}","params":{"id":1},"is_select":true}'
+```
+
+Ví dụ thực thi lệnh `INSERT`:
+
+```bash
+Invoke-RestMethod -Uri http://localhost:8000/sql/ `
+  -Method POST -ContentType 'application/json' `
+  -Body '{"sql":"INSERT INTO dim_products (id, name) VALUES ({id:UInt64}, {name:String})","params":{"id":10,"name":"Pen"}}'
+```
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
-from app.routers import auth, users, products, orders
+from app.routers import auth, users, products, orders, dynamic
 from app.services.clickhouse_client import ClickHouseClient
 
 @asynccontextmanager
@@ -15,6 +15,7 @@ app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(products.router)
 app.include_router(orders.router)
+app.include_router(dynamic.router)
 
 @app.get("/")
 async def root():

--- a/app/routers/dynamic.py
+++ b/app/routers/dynamic.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel
+from typing import Any, Dict, Optional
+from app.services.clickhouse_client import ClickHouseClient
+
+
+def get_ch(request: Request) -> ClickHouseClient:
+    return request.app.state.clickhouse
+
+
+router = APIRouter(prefix="/sql", tags=["sql"])
+
+
+class SQLRequest(BaseModel):
+    sql: str
+    params: Optional[Dict[str, Any]] = None
+    is_select: bool = False
+
+
+@router.post("/")
+async def execute_sql(req: SQLRequest, ch: ClickHouseClient = Depends(get_ch)):
+    """Execute arbitrary SQL against ClickHouse.
+
+    If ``is_select`` is true the rows from the query are returned, otherwise
+    the statement is executed as a command.
+    """
+    if req.is_select:
+        result = ch.query(req.sql, parameters=req.params or {})
+        return {"rows": result.result_rows}
+    ch.command(req.sql, parameters=req.params or {})
+    return {"status": "ok"}

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/orders", tags=["orders"])
 async def create_order(order: Order, ch: ClickHouseClient = Depends(get_ch)):
     # Check for existing ID to avoid duplicates
     check_sql = "SELECT count() FROM fact_orders WHERE order_id={order_id:UInt64}"
-    exists = ch.client.query(check_sql, parameters={"order_id": order.order_id}).result_rows[0][0]
+    exists = ch.query(check_sql, parameters={"order_id": order.order_id}).result_rows[0][0]
     if exists:
         raise HTTPException(status_code=400, detail="Order with this id already exists")
 
@@ -29,7 +29,7 @@ async def create_order(order: Order, ch: ClickHouseClient = Depends(get_ch)):
         "quantity": order.quantity,
         "total": order.total,
     }
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -40,7 +40,7 @@ async def read_order(order_id: int, ch: ClickHouseClient = Depends(get_ch)):
         "FROM fact_orders WHERE order_id = {order_id:UInt64}"
     )
     params = {"order_id": order_id}
-    result = ch.client.query(sql, parameters=params)
+    result = ch.query(sql, parameters=params)
     rows = result.result_rows
     if not rows:
         raise HTTPException(status_code=404, detail="Order not found")
@@ -68,7 +68,7 @@ async def update_order(order_id: int, order: Order, ch: ClickHouseClient = Depen
         "total": order.total,
         "order_id": order_id,
     }
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -76,5 +76,5 @@ async def update_order(order_id: int, order: Order, ch: ClickHouseClient = Depen
 async def delete_order(order_id: int, ch: ClickHouseClient = Depends(get_ch)):
     sql = "ALTER TABLE fact_orders DELETE WHERE order_id={order_id:UInt64}"
     params = {"order_id": order_id}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}

--- a/app/routers/products.py
+++ b/app/routers/products.py
@@ -14,13 +14,13 @@ router = APIRouter(prefix="/products", tags=["products"])
 async def create_product(product: Product, ch: ClickHouseClient = Depends(get_ch)):
     # Check for existing ID to avoid duplicates
     check_sql = "SELECT count() FROM dim_products WHERE id={id:UInt64}"
-    exists = ch.client.query(check_sql, parameters={"id": product.id}).result_rows[0][0]
+    exists = ch.query(check_sql, parameters={"id": product.id}).result_rows[0][0]
     if exists:
         raise HTTPException(status_code=400, detail="Product with this id already exists")
 
     sql = "INSERT INTO dim_products (id, name) VALUES ({id:UInt64}, {name:String})"
     params = {"id": product.id, "name": product.name}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -28,7 +28,7 @@ async def create_product(product: Product, ch: ClickHouseClient = Depends(get_ch
 async def read_product(product_id: int, ch: ClickHouseClient = Depends(get_ch)):
     sql = "SELECT id, name FROM dim_products WHERE id = {product_id:UInt64}"
     params = {"product_id": product_id}
-    result = ch.client.query(sql, parameters=params)
+    result = ch.query(sql, parameters=params)
     rows = result.result_rows
     if not rows:
         raise HTTPException(status_code=404, detail="Product not found")
@@ -40,7 +40,7 @@ async def read_product(product_id: int, ch: ClickHouseClient = Depends(get_ch)):
 async def update_product(product_id: int, product: Product, ch: ClickHouseClient = Depends(get_ch)):
     sql = "ALTER TABLE dim_products UPDATE name={name:String} WHERE id={product_id:UInt64}"
     params = {"name": product.name, "product_id": product_id}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -48,5 +48,5 @@ async def update_product(product_id: int, product: Product, ch: ClickHouseClient
 async def delete_product(product_id: int, ch: ClickHouseClient = Depends(get_ch)):
     sql = "ALTER TABLE dim_products DELETE WHERE id={product_id:UInt64}"
     params = {"product_id": product_id}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -14,13 +14,13 @@ router = APIRouter(prefix="/users", tags=["users"])
 async def create_user(user: User, ch: ClickHouseClient = Depends(get_ch)):
     # Check for existing ID to avoid duplicates
     check_sql = "SELECT count() FROM dim_users WHERE id={id:UInt64}"
-    exists = ch.client.query(check_sql, parameters={"id": user.id}).result_rows[0][0]
+    exists = ch.query(check_sql, parameters={"id": user.id}).result_rows[0][0]
     if exists:
         raise HTTPException(status_code=400, detail="User with this id already exists")
 
     sql = "INSERT INTO dim_users (id, name, email) VALUES ({id:UInt64}, {name:String}, {email:String})"
     params = {"id": user.id, "name": user.name, "email": user.email}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -28,7 +28,7 @@ async def create_user(user: User, ch: ClickHouseClient = Depends(get_ch)):
 async def read_user(user_id: int, ch: ClickHouseClient = Depends(get_ch)):
     sql = "SELECT id, name, email FROM dim_users WHERE id = {user_id:UInt64}"
     params = {"user_id": user_id}
-    result = ch.client.query(sql, parameters=params)
+    result = ch.query(sql, parameters=params)
     rows = result.result_rows
     if not rows:
         raise HTTPException(status_code=404, detail="User not found")
@@ -40,7 +40,7 @@ async def read_user(user_id: int, ch: ClickHouseClient = Depends(get_ch)):
 async def update_user(user_id: int, user: User, ch: ClickHouseClient = Depends(get_ch)):
     sql = "ALTER TABLE dim_users UPDATE name={name:String}, email={email:String} WHERE id={user_id:UInt64}"
     params = {"name": user.name, "email": user.email, "user_id": user_id}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}
 
 
@@ -48,5 +48,5 @@ async def update_user(user_id: int, user: User, ch: ClickHouseClient = Depends(g
 async def delete_user(user_id: int, ch: ClickHouseClient = Depends(get_ch)):
     sql = "ALTER TABLE dim_users DELETE WHERE id={user_id:UInt64}"
     params = {"user_id": user_id}
-    ch.client.command(sql, parameters=params)
+    ch.command(sql, parameters=params)
     return {"status": "ok"}

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -21,11 +21,18 @@ class ClickHouseClient:
             database=settings.CLICKHOUSE_DATABASE,
         )
 
-    def command(self, sql: str):
-        return self.client.command(sql)
+    def command(self, sql: str, parameters: dict | None = None):
+        """Execute a non-select statement.
 
-    def query(self, sql: str):
-        return self.client.query(sql)
+        Parameters can be passed in to dynamically substitute values in the
+        query.  This allows the API layer to work with arbitrary statements
+        without string formatting.
+        """
+        return self.client.command(sql, parameters=parameters or {})
+
+    def query(self, sql: str, parameters: dict | None = None):
+        """Execute a select statement and return the raw ClickHouse result."""
+        return self.client.query(sql, parameters=parameters or {})
 
     def init_db(self):
         self.command(


### PR DESCRIPTION
## Summary
- expose generic /sql endpoint that runs arbitrary ClickHouse statements with parameters
- allow ClickHouseClient.query/command to accept parameters and update CRUD routers to use them
- document usage of dynamic SQL in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689563c5aa2c832bb37d46cb072bfd12