### PR TITLE
Use ClickHouse table for auth users

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,18 +1,18 @@
-from fastapi import APIRouter, HTTPException, status, Depends
+from fastapi import APIRouter, HTTPException, status, Depends, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 from loguru import logger
+import hashlib
 
 from app.core.security import create_access_token
+from app.services.clickhouse_client import ClickHouseClient
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-fake_users_db = {
-    "admin": {
-        "username": "admin",
-        "password": "password",
-    }
-}
+
+def get_ch(request: Request) -> ClickHouseClient:
+    """Lấy đối tượng ClickHouseClient từ ứng dụng."""
+    return request.app.state.clickhouse
 
 
 class RegisterForm(BaseModel):
@@ -23,15 +23,17 @@ class RegisterForm(BaseModel):
 
 
 @router.post("/register")
-async def register(user: RegisterForm):
+async def register(user: RegisterForm, ch: ClickHouseClient = Depends(get_ch)):
     """Đăng ký tài khoản mới và trả về token truy cập."""
     try:
-        if user.username in fake_users_db:
+        check_sql = "SELECT count() FROM users_auth WHERE username={username:String}"
+        exists = ch.query(check_sql, parameters={"username": user.username}).result_rows[0][0]
+        if exists:
             raise HTTPException(status_code=400, detail="Username already registered")
-        fake_users_db[user.username] = {
-            "username": user.username,
-            "password": user.password,
-        }
+        password_hash = hashlib.sha256(user.password.encode()).hexdigest()
+        sql = "INSERT INTO users_auth (username, password_hash) VALUES ({username:String}, {password_hash:String})"
+        params = {"username": user.username, "password_hash": password_hash}
+        ch.command(sql, parameters=params)
         access_token = create_access_token(data={"sub": user.username})
         logger.info("Người dùng {} đã đăng ký", user.username)
         return {"access_token": access_token, "token_type": "bearer"}
@@ -43,21 +45,29 @@ async def register(user: RegisterForm):
 
 
 @router.post("/login")
-async def login(form_data: OAuth2PasswordRequestForm = Depends()):
+async def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    ch: ClickHouseClient = Depends(get_ch),
+):
     """Đăng nhập và trả về token truy cập."""
     try:
-        user = fake_users_db.get(form_data.username)
-        if not user or user["password"] != form_data.password:
+        sql = "SELECT password_hash FROM users_auth WHERE username={username:String}"
+        params = {"username": form_data.username}
+        result = ch.query(sql, parameters=params)
+        rows = result.result_rows
+        password_hash = hashlib.sha256(form_data.password.encode()).hexdigest()
+        if not rows or rows[0][0] != password_hash:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Incorrect username or password",
                 headers={"WWW-Authenticate": "Bearer"},
             )
-        access_token = create_access_token(data={"sub": user["username"]})
-        logger.info("Người dùng {} đăng nhập", user["username"])
+        access_token = create_access_token(data={"sub": form_data.username})
+        logger.info("Người dùng {} đăng nhập", form_data.username)
         return {"access_token": access_token, "token_type": "bearer"}
     except HTTPException:
         raise
     except Exception as exc:
         logger.exception("Lỗi đăng nhập: {}", exc)
         raise HTTPException(status_code=500, detail="Lỗi máy chủ")
+

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -79,4 +79,13 @@ class ClickHouseClient:
             ORDER BY order_id
             """
         )
+        self.command(
+            """
+            CREATE TABLE IF NOT EXISTS users_auth (
+                username String,
+                password_hash String
+            ) ENGINE = MergeTree()
+            ORDER BY username
+            """
+        )
 


### PR DESCRIPTION
## Summary
- create `users_auth` table in ClickHouse for storing credentials
- hash passwords and persist them in ClickHouse during registration
- verify hashed passwords from ClickHouse on login

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7d51d9314832486c590822c17e29d