### PR TITLE
feat: add generic CRUD endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,45 @@ Invoke-RestMethod -Uri http://localhost:8000/sql/ `
   -Body '{"sql":"INSERT INTO dim_products (id, name) VALUES ({id:UInt64}, {name:String})","params":{"id":10,"name":"Pen"}}'
 ```
 
+### CRUD động theo schema
+
+Router `/crud` cho phép thao tác với bất kỳ bảng nào bằng cách tự lấy schema từ
+ClickHouse, giúp giảm công viết API cho mỗi bảng mới.
+
+Tạo bản ghi mới:
+
+```bash
+Invoke-RestMethod -Uri http://localhost:8000/crud/dim_users `
+  -Method POST -ContentType 'application/json' `
+  -Body '{"id":5,"name":"User5","email":"user5@example.com"}'
+```
+
+Đọc bản ghi:
+
+```bash
+Invoke-RestMethod -Uri "http://localhost:8000/crud/dim_users/5" `
+  -Method GET
+```
+
+Cập nhật bản ghi:
+
+```bash
+Invoke-RestMethod -Uri http://localhost:8000/crud/dim_users/5 `
+  -Method PUT -ContentType 'application/json' `
+  -Body '{"name":"User5 Updated"}'
+```
+
+Xóa bản ghi:
+
+```bash
+Invoke-RestMethod -Uri "http://localhost:8000/crud/dim_users/5" `
+  -Method DELETE
+```
+
+Nếu bảng dùng khóa khác `id`, truyền tên cột qua tham số `id_column`:
+
+```bash
+Invoke-RestMethod -Uri "http://localhost:8000/crud/fact_orders/1?id_column=order_id" `
+  -Method GET
+```
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
 from loguru import logger
-from app.routers import auth, users, products, orders, dynamic
+from app.routers import auth, users, products, orders, dynamic, crud
 from app.services.clickhouse_client import ClickHouseClient
 
 @asynccontextmanager
@@ -22,6 +22,7 @@ app.include_router(users.router)
 app.include_router(products.router)
 app.include_router(orders.router)
 app.include_router(dynamic.router)
+app.include_router(crud.router)
 
 @app.get("/")
 async def root():

--- a/app/routers/crud.py
+++ b/app/routers/crud.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, Depends, Request, HTTPException
+from typing import Any, Dict
+from loguru import logger
+from app.services.clickhouse_client import ClickHouseClient
+
+
+def get_ch(request: Request) -> ClickHouseClient:
+    """Lấy đối tượng ClickHouseClient từ ứng dụng."""
+    return request.app.state.clickhouse
+
+
+router = APIRouter(prefix="/crud", tags=["crud"])
+
+
+def _schema_dict(ch: ClickHouseClient, table: str) -> tuple[list[tuple[str, str]], dict[str, str]]:
+    columns = ch.get_table_schema(table)
+    schema = {name: dtype for name, dtype in columns}
+    return columns, schema
+
+
+def _cast_value(value: str, ch_type: str) -> Any:
+    """Chuyển đổi giá trị từ chuỗi theo kiểu dữ liệu ClickHouse."""
+    try:
+        if ch_type.startswith("UInt") or ch_type.startswith("Int"):
+            return int(value)
+        if ch_type.startswith("Float"):
+            return float(value)
+        return value
+    except Exception:
+        return value
+
+
+@router.post("/{table}")
+async def create_row(table: str, data: Dict[str, Any], ch: ClickHouseClient = Depends(get_ch)):
+    """Chèn bản ghi mới vào bảng bất kỳ."""
+    columns, schema = _schema_dict(ch, table)
+    unknown = set(data) - set(schema)
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown columns: {', '.join(unknown)}")
+    cols = list(data.keys())
+    cols_str = ", ".join(cols)
+    placeholders = ", ".join([f"{{{c}:{schema[c]}}}" for c in cols])
+    sql = f"INSERT INTO {table} ({cols_str}) VALUES ({placeholders})"
+    ch.command(sql, parameters=data)
+    logger.info("Chèn dữ liệu vào bảng {}", table)
+    return {"status": "ok"}
+
+
+@router.get("/{table}/{item_id}")
+async def read_row(table: str, item_id: str, id_column: str = "id", ch: ClickHouseClient = Depends(get_ch)):
+    """Đọc một bản ghi theo khóa chính."""
+    columns, schema = _schema_dict(ch, table)
+    if id_column not in schema:
+        raise HTTPException(status_code=400, detail="Invalid id column")
+    id_value = _cast_value(item_id, schema[id_column])
+    sql = f"SELECT * FROM {table} WHERE {id_column}={{{id_column}:{schema[id_column]}}}"
+    result = ch.query(sql, parameters={id_column: id_value})
+    rows = result.result_rows
+    if not rows:
+        raise HTTPException(status_code=404, detail="Row not found")
+    row = rows[0]
+    return {col: row[idx] for idx, (col, _) in enumerate(columns)}
+
+
+@router.put("/{table}/{item_id}")
+async def update_row(table: str, item_id: str, data: Dict[str, Any], id_column: str = "id", ch: ClickHouseClient = Depends(get_ch)):
+    """Cập nhật bản ghi theo khóa chính."""
+    _, schema = _schema_dict(ch, table)
+    if id_column not in schema:
+        raise HTTPException(status_code=400, detail="Invalid id column")
+    unknown = set(data) - set(schema)
+    if unknown:
+        raise HTTPException(status_code=400, detail=f"Unknown columns: {', '.join(unknown)}")
+    set_clause = ", ".join([f"{c}={{{c}:{schema[c]}}}" for c in data.keys()])
+    sql = f"ALTER TABLE {table} UPDATE {set_clause} WHERE {id_column}={{{id_column}:{schema[id_column]}}}"
+    params = {**data, id_column: _cast_value(item_id, schema[id_column])}
+    ch.command(sql, parameters=params)
+    logger.info("Cập nhật dữ liệu bảng {}", table)
+    return {"status": "ok"}
+
+
+@router.delete("/{table}/{item_id}")
+async def delete_row(table: str, item_id: str, id_column: str = "id", ch: ClickHouseClient = Depends(get_ch)):
+    """Xóa bản ghi theo khóa chính."""
+    _, schema = _schema_dict(ch, table)
+    if id_column not in schema:
+        raise HTTPException(status_code=400, detail="Invalid id column")
+    sql = f"ALTER TABLE {table} DELETE WHERE {id_column}={{{id_column}:{schema[id_column]}}}"
+    ch.command(sql, parameters={id_column: _cast_value(item_id, schema[id_column])})
+    logger.info("Xóa dữ liệu bảng {}", table)
+    return {"status": "ok"}

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -45,6 +45,15 @@ class ClickHouseClient:
             logger.exception("Lỗi khi thực thi query: {}", exc)
             raise
 
+    def get_table_schema(self, table: str) -> list[tuple[str, str]]:
+        """Lấy danh sách cột và kiểu dữ liệu của một bảng."""
+        try:
+            result = self.query(f"DESCRIBE TABLE {table}")
+            return [(row[0], row[1]) for row in result.result_rows]
+        except Exception as exc:
+            logger.exception("Không thể lấy schema cho bảng {}: {}", table, exc)
+            raise
+
     def init_db(self):
         """Khởi tạo các bảng cần thiết nếu chưa tồn tại."""
         self.command(


### PR DESCRIPTION
## Summary
- expose schema-based generic CRUD router
- fetch table metadata from ClickHouse for dynamic queries
- register generic CRUD endpoints in application
- document usage for dynamic CRUD endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a7e20052fc8324a477681d8629f1b6