### PR TITLE
Improve ClickHouse host resolution

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,7 +9,8 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "my-secret-key"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
-    CLICKHOUSE_HOST: str = "clickhouse"
+    # Mặc định trỏ tới máy cục bộ để tránh lỗi không resolve được DNS
+    CLICKHOUSE_HOST: str = "localhost"
     CLICKHOUSE_PORT: int = 8123
     CLICKHOUSE_USER: str = "admin"
     CLICKHOUSE_PASSWORD: str = "password"

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -18,13 +18,30 @@ class ClickHouseClient:
     def _connect(self):
         """Tạo kết nối tới máy chủ ClickHouse."""
         logger.info("Kết nối tới ClickHouse")
-        return get_client(
-            host=settings.CLICKHOUSE_HOST,
-            port=settings.CLICKHOUSE_PORT,
-            username=settings.CLICKHOUSE_USER,
-            password=settings.CLICKHOUSE_PASSWORD,
-            database=settings.CLICKHOUSE_DATABASE,
-        )
+        try:
+            return get_client(
+                host=settings.CLICKHOUSE_HOST,
+                port=settings.CLICKHOUSE_PORT,
+                username=settings.CLICKHOUSE_USER,
+                password=settings.CLICKHOUSE_PASSWORD,
+                database=settings.CLICKHOUSE_DATABASE,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Không thể kết nối tới host {}: {}",
+                settings.CLICKHOUSE_HOST,
+                exc,
+            )
+            if settings.CLICKHOUSE_HOST != "localhost":
+                logger.info("Thử kết nối tới localhost")
+                return get_client(
+                    host="localhost",
+                    port=settings.CLICKHOUSE_PORT,
+                    username=settings.CLICKHOUSE_USER,
+                    password=settings.CLICKHOUSE_PASSWORD,
+                    database=settings.CLICKHOUSE_DATABASE,
+                )
+            raise
 
     def command(self, sql: str, parameters: Optional[Dict] = None):
         """Thực thi câu lệnh không phải ``SELECT``.


### PR DESCRIPTION
## Summary
- default ClickHouse host to localhost
- retry connection with localhost if configured host cannot be resolved

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68afd3aa6010832491af9910576319ee