### PR TITLE
Improve ClickHouse host resolution and table error handling

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -9,7 +9,8 @@ class Settings(BaseSettings):
     SECRET_KEY: str = "my-secret-key"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
-    CLICKHOUSE_HOST: str = "clickhouse"
+    # Mặc định trỏ tới máy cục bộ để tránh lỗi không resolve được DNS
+    CLICKHOUSE_HOST: str = "localhost"
     CLICKHOUSE_PORT: int = 8123
     CLICKHOUSE_USER: str = "admin"
     CLICKHOUSE_PASSWORD: str = "password"

--- a/app/routers/crud.py
+++ b/app/routers/crud.py
@@ -24,6 +24,9 @@ def _schema_dict(
         raise
     except Exception as exc:
         logger.exception("Lỗi lấy schema bảng {}: {}", table, exc)
+        message = str(exc).lower()
+        if "doesn't exist" in message or "unknown table" in message:
+            raise HTTPException(status_code=404, detail="Bảng không tồn tại")
         raise HTTPException(status_code=500, detail="Lỗi máy chủ")
 
 

--- a/app/services/clickhouse_client.py
+++ b/app/services/clickhouse_client.py
@@ -18,13 +18,30 @@ class ClickHouseClient:
     def _connect(self):
         """Tạo kết nối tới máy chủ ClickHouse."""
         logger.info("Kết nối tới ClickHouse")
-        return get_client(
-            host=settings.CLICKHOUSE_HOST,
-            port=settings.CLICKHOUSE_PORT,
-            username=settings.CLICKHOUSE_USER,
-            password=settings.CLICKHOUSE_PASSWORD,
-            database=settings.CLICKHOUSE_DATABASE,
-        )
+        try:
+            return get_client(
+                host=settings.CLICKHOUSE_HOST,
+                port=settings.CLICKHOUSE_PORT,
+                username=settings.CLICKHOUSE_USER,
+                password=settings.CLICKHOUSE_PASSWORD,
+                database=settings.CLICKHOUSE_DATABASE,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Không thể kết nối tới host {}: {}",
+                settings.CLICKHOUSE_HOST,
+                exc,
+            )
+            if settings.CLICKHOUSE_HOST != "localhost":
+                logger.info("Thử kết nối tới localhost")
+                return get_client(
+                    host="localhost",
+                    port=settings.CLICKHOUSE_PORT,
+                    username=settings.CLICKHOUSE_USER,
+                    password=settings.CLICKHOUSE_PASSWORD,
+                    database=settings.CLICKHOUSE_DATABASE,
+                )
+            raise
 
     def command(self, sql: str, parameters: Optional[Dict] = None):
         """Thực thi câu lệnh không phải ``SELECT``.

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+
+# Đảm bảo thư mục gốc của dự án có trong sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.routers.crud import _schema_dict
+
+
+class FakeClient:
+    def get_table_schema(self, table: str):
+        raise Exception("Code: 60, DB::Exception: Table default.users doesn't exist")
+
+
+def test_schema_dict_table_not_found():
+    client = FakeClient()
+    with pytest.raises(HTTPException) as exc:
+        _schema_dict(client, "users")
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Summary
- default ClickHouse host to localhost
- retry connection with localhost if configured host cannot be resolved
- return 404 when querying non-existent tables instead of 500
- add unit test for missing table scenario

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68afd3aa6010832491af9910576319ee