### PR TITLE
Enable multi-field querying in CRUD UI

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -8,19 +8,43 @@
     <h1>Query Table</h1>
     <form id="query-form">
         <label>Table: <input type="text" id="table" required></label>
-        <label>ID: <input type="text" id="itemId" required></label>
+        <div id="filters"></div>
+        <button type="button" id="add-filter">Add Filter</button>
         <button type="submit">Fetch</button>
     </form>
     <pre id="result"></pre>
     <script>
+        function addFilter() {
+            const div = document.createElement('div');
+            div.className = 'filter';
+            div.innerHTML = `
+                <input type="text" class="field" placeholder="Column">
+                <input type="text" class="value" placeholder="Value">
+                <button type="button" class="remove">Remove</button>`;
+            document.getElementById('filters').appendChild(div);
+        }
+
+        document.getElementById('add-filter').addEventListener('click', addFilter);
+        document.getElementById('filters').addEventListener('click', function(e) {
+            if (e.target.classList.contains('remove')) {
+                e.target.parentElement.remove();
+            }
+        });
+
         document.getElementById('query-form').addEventListener('submit', async function(e) {
             e.preventDefault();
             const table = document.getElementById('table').value;
-            const id = document.getElementById('itemId').value;
+            const params = new URLSearchParams();
+            document.querySelectorAll('#filters .filter').forEach(f => {
+                const field = f.querySelector('.field').value.trim();
+                const value = f.querySelector('.value').value.trim();
+                if (field) params.append(field, value);
+            });
+            const query = params.toString();
             const resultEl = document.getElementById('result');
             resultEl.textContent = 'Loading...';
             try {
-                const res = await fetch(`/crud/${table}/${id}`);
+                const res = await fetch(`/crud/${table}${query ? '?' + query : ''}`);
                 if (!res.ok) {
                     const text = await res.text();
                     resultEl.textContent = `Error ${res.status}: ${text}`;


### PR DESCRIPTION
## Summary
- support querying tables with flexible filters via `/crud/{table}` GET endpoint
- update demo UI to add/remove arbitrary filters and build query strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68afda2202948324b99507035b70f6a8