### PR TITLE
Enable multi-field querying in React-based CRUD UI

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,37 +1,136 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
+    <meta charset="UTF-8" />
     <title>FastAPI ClickHouse Demo</title>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f5f5f5;
+            margin: 2rem;
+        }
+        .container {
+            background: #fff;
+            padding: 1.5rem 2rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            max-width: 700px;
+            margin: auto;
+        }
+        h1 {
+            text-align: center;
+        }
+        .filter {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 0.5rem;
+        }
+        .filter input {
+            flex: 1;
+            padding: 0.4rem;
+        }
+        .buttons {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 0.5rem;
+        }
+        button {
+            padding: 0.4rem 0.8rem;
+        }
+        pre {
+            background: #272822;
+            color: #f8f8f2;
+            padding: 1rem;
+            border-radius: 4px;
+            overflow: auto;
+        }
+    </style>
 </head>
 <body>
-    <h1>Query Table</h1>
-    <form id="query-form">
-        <label>Table: <input type="text" id="table" required></label>
-        <label>ID: <input type="text" id="itemId" required></label>
-        <button type="submit">Fetch</button>
-    </form>
-    <pre id="result"></pre>
-    <script>
-        document.getElementById('query-form').addEventListener('submit', async function(e) {
-            e.preventDefault();
-            const table = document.getElementById('table').value;
-            const id = document.getElementById('itemId').value;
-            const resultEl = document.getElementById('result');
-            resultEl.textContent = 'Loading...';
-            try {
-                const res = await fetch(`/crud/${table}/${id}`);
-                if (!res.ok) {
-                    const text = await res.text();
-                    resultEl.textContent = `Error ${res.status}: ${text}`;
-                    return;
+    <div id="root"></div>
+    <script type="text/babel">
+        const { useState } = React;
+
+        function App() {
+            const [table, setTable] = useState('');
+            const [filters, setFilters] = useState([{ field: '', value: '' }]);
+            const [result, setResult] = useState('');
+
+            const updateFilter = (index, key, value) => {
+                const updated = filters.slice();
+                updated[index][key] = value;
+                setFilters(updated);
+            };
+
+            const addFilter = () => setFilters([...filters, { field: '', value: '' }]);
+            const removeFilter = (index) => setFilters(filters.filter((_, i) => i !== index));
+
+            const submit = async (e) => {
+                e.preventDefault();
+                const params = new URLSearchParams();
+                filters.forEach(f => {
+                    const field = f.field.trim();
+                    const value = f.value.trim();
+                    if (field) params.append(field, value);
+                });
+                const query = params.toString();
+                setResult('Loading...');
+                try {
+                    const res = await fetch(
+                        `/crud/${encodeURIComponent(table.trim())}${query ? '?' + query : ''}`,
+                        { method: 'GET' }
+                    );
+                    if (!res.ok) {
+                        const text = await res.text();
+                        setResult(`Error ${res.status}: ${text}`);
+                        return;
+                    }
+                    const data = await res.json();
+                    setResult(JSON.stringify(data, null, 2));
+                } catch (err) {
+                    setResult(err.toString());
                 }
-                const data = await res.json();
-                resultEl.textContent = JSON.stringify(data, null, 2);
-            } catch (err) {
-                resultEl.textContent = err.toString();
-            }
-        });
+            };
+
+            return (
+                <div className="container">
+                    <h1>Query Table</h1>
+                    <form onSubmit={submit}>
+                        <div className="filter">
+                            <label style={{flex: 1}}>
+                                Table:
+                                <input value={table} onChange={e => setTable(e.target.value)} required />
+                            </label>
+                        </div>
+                        {filters.map((f, idx) => (
+                            <div className="filter" key={idx}>
+                                <input
+                                    placeholder="Column"
+                                    value={f.field}
+                                    onChange={e => updateFilter(idx, 'field', e.target.value)}
+                                />
+                                <input
+                                    placeholder="Value"
+                                    value={f.value}
+                                    onChange={e => updateFilter(idx, 'value', e.target.value)}
+                                />
+                                <button type="button" onClick={() => removeFilter(idx)}>Remove</button>
+                            </div>
+                        ))}
+                        <div className="buttons">
+                            <button type="button" onClick={addFilter}>Add Filter</button>
+                            <button type="submit">Fetch</button>
+                        </div>
+                    </form>
+                    <pre>{result}</pre>
+                </div>
+            );
+        }
+
+        ReactDOM.render(<App />, document.getElementById('root'));
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support querying tables with flexible filters via `/crud/{table}` GET endpoint
- revamp demo interface using React for a cleaner dynamic filter UI
- ensure query UI fetches with explicit GET to avoid 405 errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68afda2202948324b99507035b70f6a8