### PR TITLE
feat: add aggregation queries to UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,17 @@ python scripts/generate_parquet.py --rows 10000000 --cols 10 --output data10m.pa
 
 ## Simple frontend
 
-A minimal HTML page is served at `/frontend` that lets you query any table via
-the dynamic CRUD endpoint.  Enter a table name and row id and the page will
-display the JSON response returned by the API.
+Trang HTML đơn giản được phục vụ tại `/frontend` cho phép bạn truy vấn bất kỳ
+bảng nào thông qua endpoint CRUD động.
+
+### Hướng dẫn sử dụng
+1. Mở trình duyệt truy cập `http://localhost:8000/frontend`.
+2. Nhập tên bảng vào ô **Table**.
+3. (Tuỳ chọn) Chọn hàm tổng hợp và cột cần tính ở phần **Function** và
+   **Aggregate Column**. Có thể nhập cột **Group By** để nhóm kết quả.
+4. (Tuỳ chọn) Thêm bộ lọc bằng nút **Add Filter**, mỗi bộ lọc gồm cột và giá trị
+   cần so khớp. Có thể thêm nhiều bộ lọc.
+5. Nhấn **Fetch** để gửi yêu cầu; kết quả JSON sẽ hiển thị ở khung bên dưới.
 
 ## Check downtime: 
 ```bash

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -57,6 +57,9 @@
         function App() {
             const [table, setTable] = useState('');
             const [filters, setFilters] = useState([{ field: '', value: '' }]);
+            const [aggFunc, setAggFunc] = useState('');
+            const [aggField, setAggField] = useState('');
+            const [groupBy, setGroupBy] = useState('');
             const [result, setResult] = useState('');
 
             const updateFilter = (index, key, value) => {
@@ -76,6 +79,12 @@
                     const value = f.value.trim();
                     if (field) params.append(field, value);
                 });
+                if (aggFunc && aggField) {
+                    params.append('aggregate', `${aggFunc}:${aggField}`);
+                }
+                if (groupBy) {
+                    params.append('group_by', groupBy);
+                }
                 const query = params.toString();
                 setResult('Loading...');
                 try {
@@ -104,6 +113,30 @@
                             <label style={{flex: 1}}>
                                 Table:
                                 <input value={table} onChange={e => setTable(e.target.value)} required />
+                            </label>
+                        </div>
+                        <div className="filter">
+                            <label>
+                                Function:
+                                <select value={aggFunc} onChange={e => setAggFunc(e.target.value)}>
+                                    <option value="">None</option>
+                                    <option value="count">COUNT</option>
+                                    <option value="sum">SUM</option>
+                                    <option value="avg">AVG</option>
+                                    <option value="min">MIN</option>
+                                    <option value="max">MAX</option>
+                                </select>
+                            </label>
+                            <input
+                                placeholder="Aggregate Column"
+                                value={aggField}
+                                onChange={e => setAggField(e.target.value)}
+                            />
+                        </div>
+                        <div className="filter">
+                            <label style={{flex: 1}}>
+                                Group By:
+                                <input value={groupBy} onChange={e => setGroupBy(e.target.value)} />
                             </label>
                         </div>
                         {filters.map((f, idx) => (

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -3,12 +3,13 @@ from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import QueryParams
 
 
 # Đảm bảo thư mục gốc của dự án có trong sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from app.routers.crud import _schema_dict
+from app.routers.crud import _schema_dict, query_rows
 
 
 class FakeClient:
@@ -21,3 +22,46 @@ def test_schema_dict_table_not_found():
     with pytest.raises(HTTPException) as exc:
         _schema_dict(client, "users")
     assert exc.value.status_code == 404
+
+
+class FakeQueryClient:
+    def __init__(self):
+        self.sql = None
+        self.parameters = None
+
+    def get_table_schema(self, table: str):
+        return [
+            ("order_id", "UInt64"),
+            ("user_id", "UInt64"),
+            ("status", "String"),
+        ]
+
+    def query(self, sql: str, parameters=None):
+        self.sql = sql
+        self.parameters = parameters
+
+        class Result:
+            result_rows = [(2, "active")]
+
+        return Result()
+
+
+class SimpleRequest:
+    def __init__(self, qp: QueryParams):
+        self.query_params = qp
+
+
+def test_query_rows_with_aggregate():
+    client = FakeQueryClient()
+    qp = QueryParams("aggregate=count:order_id&status=active&group_by=status")
+    req = SimpleRequest(qp)
+    import asyncio
+
+    res = asyncio.get_event_loop().run_until_complete(
+        query_rows("fact_orders", req, ch=client)
+    )
+    assert (
+        client.sql
+        == "SELECT COUNT(order_id) AS count_order_id, status FROM fact_orders WHERE status={status:String} GROUP BY status"
+    )
+    assert res == [{"count_order_id": 2, "status": "active"}]


### PR DESCRIPTION
## Summary
- allow CRUD query endpoint to perform aggregations with optional group by and filters
- expose aggregation options in React UI
- cover aggregate query path with new tests
- document how to run aggregated queries from the frontend in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b024f0530c8324b9d137b2de3899ba